### PR TITLE
Fill in Ubuntu suite dynamically so that the script also works in trusty

### DIFF
--- a/ros_ci_bootstrap
+++ b/ros_ci_bootstrap
@@ -2,6 +2,7 @@
 
 # Env defaults
 [ -z "$ROS_DISTRO" ] && ROS_DISTRO="hydro"
+[ -z "$UBUNTU_SUITE" ] && UBUNTU_SUITE=$(lsb_release -cs)
 #[ -z "$SRC_PATHS" ] && SRC_PATHS=$(pwd)
 
 # Allow the user to specify shadow-fixed debian packages, which have newer versions of packages
@@ -19,7 +20,7 @@ fi
 echo "[ros_ci_tools] Bootstraping a ROS $ROS_DISTRO installation from the "$DEB_REPO" repositories..."
 
 # Add the ubuntu package repos
-sudo sh -c "echo \"deb http://packages.ros.org/$DEB_REPO/ubuntu precise main\" > /etc/apt/sources.list.d/ros-latest.list"
+sudo sh -c "echo \"deb http://packages.ros.org/$DEB_REPO/ubuntu $UBUNTU_SUITE main\" > /etc/apt/sources.list.d/ros-latest.list"
 # Get the apt key
 wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
 


### PR DESCRIPTION
Travis supports Ubuntu trusty now (see http://docs.travis-ci.com/user/trusty-ci-environment/), so this script should be independent of the installed Ubuntu version.

Related: https://github.com/orocos/rtt_ros_integration/pull/49
